### PR TITLE
Remove LnD filepath references

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -2,7 +2,7 @@
 
 set -e
 
-PROD_DIR=/groups/dungeons/pipeline
+PROD_DIR=/groups/shrineflow/y24-pipeline
 LOCAL_DIR=$(git rev-parse --show-toplevel)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 #cp "${PROD_DIR}/pipe/accomplice/sg_config.py" "${LOCAL_DIR}/pipe/accomplice/sg_config.py"

--- a/pipeline/shared/util.py
+++ b/pipeline/shared/util.py
@@ -44,15 +44,9 @@ def get_pipe_path() -> Path:
 
 
 def get_production_path() -> Path:
-    system = platform.system()
-    if system == "Linux":
-        return Path("/groups/dungeons/production")
-    elif system == "Windows":
-        return Path("G:/dungeons/production")
-    else:
-        raise NotImplementedError(
-            "Production path is not defined for this operating system"
-        )
+    raise NotImplementedError(
+        "Production path is not defined for Shrineflow"
+    )
 
 
 def get_asset_path() -> Path:


### PR DESCRIPTION
Remove some more filepaths to Love and Dungeons, including in the checkout githook. Also, we don't have a `production` folder for Shrineflow so do not implement that util