### PR TITLE
Specify picker file to run

### DIFF
--- a/pipeline/software/maya/pipe/picker.py
+++ b/pipeline/software/maya/pipe/picker.py
@@ -1,5 +1,9 @@
 import sys, os
 
+windows_picker_filepaths = [
+    "G:\\shrineflow\\working_files\\Animation\\Picker_files\\Ninja_Picker.json"
+]
+
 def run():
     shrineflow_path_prefix = ""
     file_delin = ""
@@ -16,4 +20,8 @@ def run():
         sys.path.insert(0, lib_path)
     
     import dwpicker
-    dwpicker.show()
+    if os.name == "nt":
+        # in windows
+        dwpicker.show(pickers=windows_picker_filepaths)
+    else:
+        dwpicker.show()


### PR DESCRIPTION
Added the parameter `pickers` to the call `show` for `dwpicker` so that the window will start up with the Ninja picker loaded.