### PR TITLE
Fix Playblast Camera Exception

### DIFF
--- a/pipeline/software/maya/pipe/playblast_exporter.py
+++ b/pipeline/software/maya/pipe/playblast_exporter.py
@@ -87,7 +87,10 @@ class PlayblastExporter(QtWidgets.QMainWindow):
         r = re.compile(f'{GAME_CAMERA_NAME}\w*')
         game_cameras = list(filter(r.match, custom_cameras))
         if len(game_cameras) > 0:
-            self.cameraComboBox.setText(game_cameras[0])
+            try:
+                self.cameraComboBox.setCurrentText(game_cameras[0])
+            except:
+                print("Exception when trying to pull game camera. Select game camera manually.")
         
         self.cameraSelectLayout.addWidget(self.cameraComboBox)
         


### PR DESCRIPTION
Fixes #14 

Fix the call to set the default camera to be valid for the ComboBox. Also put a try catch so that it will print an error and continue if there's an issue with grabbing the right camera (since the user can pick the right camera manually).